### PR TITLE
Added support for segmentation

### DIFF
--- a/nautilus/api/filter.py
+++ b/nautilus/api/filter.py
@@ -1,5 +1,7 @@
 # external imports
 from graphene import List
+from graphene.core.types.scalars import Int, String
+
 # local imports
 from nautilus.contrib.graphene_peewee import convert_peewee_field
 
@@ -24,11 +26,30 @@ def args_for_model(Model):
         # add the list member filter
         fullArgs[arg + '_in'] = List(field_type)
 
+    for k in ['first', 'last', 'offset']:
+        fullArgs[k] = Int()
+    for k in ['order_by']:
+        fullArgs[k] = String()
+
     # return the complete dictionary of arguments
     return fullArgs
 
+def parse_order_by(Model, order_by):
+    out = []
+    order_by = order_by.split(",")
+    for key in order_by:
+       key = key.strip()
+       if key.startswith("+"):
+           out.append(getattr(Model, key[1:]))
+       elif key.startswith("-"):
+           out.append(getattr(Model, key[1:]).desc())
+       else:
+           out.append(getattr(Model, key))
+    return out
 
 def filter_model(Model, args):
+
+    first = last = offset = order_by = None
 
     # convert any args referencing pk to the actual field
     keys = [key.replace('pk', Model.primary_key().name) for key in args.keys()]
@@ -37,14 +58,42 @@ def filter_model(Model, args):
     models = Model.select()
     # for each argument
     for arg, value in zip(keys, args.values()):
+        if arg == "first":
+            first = value
+        elif arg == "last":
+            last = value
+        elif arg == "offset":
+            offset = value
+        elif arg == "order_by":
+            order_by = value
         # if the filter is for a group of values
-        if isinstance(value, list):
+        elif isinstance(value, list):
             model_attribute = getattr(Model, arg[:-3])
             # filter the query
             models = models.where(model_attribute.in_(value))
         else:
             # filter the argument
             models = models.where(getattr(Model, arg) == value)
+
+    if first:
+        if order_by is None:
+            order_by = "+" + Model.primary_key().name
+        order_by = parse_order_by(Model, order_by)
+        models = models.order_by(*order_by)
+        if offset:
+            models = models.offset(offset)
+        models = models.limit(first)
+    elif last:
+        if order_by is None:
+            order_by = "-" + Model.primary_key().name
+        order_by = parse_order_by(Model, order_by)
+        models = models.order_by(*order_by)
+        if offset:
+            models = models.offset(offset)
+        models = models.limit(last)
+    elif order_by:
+        order_by = parse_order_by(Model, order_by)
+        models = models.order_by(*order_by)
 
     # return the filtered list
     return list(models)

--- a/nautilus/api/objectTypes/serviceObjectType.py
+++ b/nautilus/api/objectTypes/serviceObjectType.py
@@ -50,7 +50,8 @@ class ServiceObjectTypeMeta(type(Node)):
                 for key, value in args_for_model(service.model).items():
                     # ignore dynamically created fields
                     # TODO: make this cleaner
-                    if 'pk' not in key and 'in' not in key and 'id' not in key:
+                    if key not in ['pk', 'id', 'first', 'last', 'offset', 'order_by'] \
+                            and not key.endswith("_in"):
                         # add an attribute to the cls that matches the argument
                         attributes[key] = value
 

--- a/tests/api/test_filter.py
+++ b/tests/api/test_filter.py
@@ -23,11 +23,24 @@ class TestUtil(unittest.TestCase):
         # create a database table to test on
         nautilus.db.create_table(self.model)
 
+        # generate test data
+        self.gen_testdata()
+
 
     def tearDown(self):
         # remove the test table
         nautilus.db.drop_table(self.model)
 
+
+    def gen_testdata(self):
+        # some test records
+        i = 1
+        while i < 10:
+            record = self.model(first_name='foo%s' % (i), last_name='bar')
+            record.save()
+            record = self.model(first_name='bar%s' % (i), last_name='foo')
+            record.save()
+            i +=1
 
     def test_args_match_model(self):
         # make sure the argument contain the model fields
@@ -53,15 +66,8 @@ class TestUtil(unittest.TestCase):
 
 
     def test_can_filter_by_field(self):
-        # some test records
-        record1 = self.model(first_name='foo', last_name='bar')
-        record2 = self.model(first_name='bar', last_name='foo')
-        # save the record to the database
-        record1.save()
-        record2.save()
-
         # the argument to filter for
-        filter_args = dict(first_name=record1.first_name)
+        filter_args = dict(first_name='foo1')
         # filter the models
         records_filtered = filter_model(self.model, filter_args)
 
@@ -71,23 +77,17 @@ class TestUtil(unittest.TestCase):
         )
 
         # pull out the retrieved record
-        retrieved_record = records_filtered[0]
+        retrieved_record_first_name = records_filtered[0].first_name
         # make sure the first name matches
-        assert retrieved_record.first_name == record1.first_name, (
-            "The wrong record was retrieved."
+        expected = 'foo1'
+        assert retrieved_record_first_name == expected, (
+            "Got %(retrieved_record_first_name)s instead of %(expected)s" % locals()
         )
 
 
     def test_can_filter_by_contains(self):
-        # some test records
-        record1 = self.model(first_name='foo', last_name='bar')
-        record2 = self.model(first_name='bar', last_name='foo')
-        # save the record to the database
-        record1.save()
-        record2.save()
-
         # the argument to filter for
-        filter_args = dict(first_name_in=[record1.first_name, record2.first_name])
+        filter_args = dict(first_name_in=['foo1', 'foo2'])
         # filter the models
         records_filtered = filter_model(self.model, filter_args)
 
@@ -100,6 +100,77 @@ class TestUtil(unittest.TestCase):
         retrieved_names = {record.first_name for record in records_filtered}
 
         # make sure the first name matches
-        assert retrieved_names == {record1.first_name, record2.first_name}, (
-            "The wrong record was retrieved."
+        expected = {'foo1', 'foo2'}
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
+        )
+
+
+    def test_can_handle_first(self):
+        # the argument to filter for
+        filter_args = dict(first=2, offset=0)
+        # filter the models
+        records_filtered = filter_model(self.model, filter_args)
+
+        # figure out the names of the records we retrieved
+        retrieved_names = [record.first_name for record in records_filtered]
+        expected = ['foo1', 'bar1']
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
+        )
+
+
+    def test_can_handle_last(self):
+        # the argument to filter for
+        filter_args = dict(last=2, offset=0)
+        # filter the models
+        records_filtered = filter_model(self.model, filter_args)
+
+        # figure out the names of the records we retrieved
+        retrieved_names = [record.first_name for record in records_filtered]
+        expected = ['bar9', 'foo9']
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
+        )
+
+
+    def test_can_handle_last_offset(self):
+        # the argument to filter for
+        filter_args = dict(last=2, offset=2)
+        # filter the models
+        records_filtered = filter_model(self.model, filter_args)
+
+        # figure out the names of the records we retrieved
+        retrieved_names = [record.first_name for record in records_filtered]
+        expected = ['bar8', 'foo8']
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
+        )
+
+
+    def test_can_handle_first_offset(self):
+        # the argument to filter for
+        filter_args = dict(first=4, offset=2)
+        # filter the models
+        records_filtered = filter_model(self.model, filter_args)
+
+        # figure out the names of the records we retrieved
+        retrieved_names = [record.first_name for record in records_filtered]
+        expected = ['foo2', 'bar2', 'foo3', 'bar3']
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
+        )
+
+
+    def test_can_handle_first_offset_order_by(self):
+        # the argument to filter for
+        filter_args = dict(first=4, offset=2, order_by="last_name, -first_name")
+        # filter the models
+        records_filtered = filter_model(self.model, filter_args)
+
+        # figure out the names of the records we retrieved
+        retrieved_names = [record.first_name for record in records_filtered]
+        expected = ['foo7', 'foo6', 'foo5', 'foo4']
+        assert retrieved_names == expected, (
+            "Got %(retrieved_names)s instead of %(expected)s" % locals()
         )


### PR DESCRIPTION
First is forward scrolling from offset if given.
Last is reverse scrolling from offset if given.
Default order_by is the primary key. To order on multiple columns, separate the fields with ",". To optionally specify ascending or descending order, prepend a "+" or "-" to the field. E.g. "-first_name, last_name".