### PR TITLE
added debug flag to service manager

### DIFF
--- a/nautilus/services/service.py
+++ b/nautilus/services/service.py
@@ -103,6 +103,7 @@ class Service(metaclass=ServiceMetaClass):
         # create a tornado web application
         app = tornado.web.Application(
             self.request_handlers,
+            debug= self.config.debug if 'debug' in self.config else False,
         )
         # attach the ioloop to the application
         app.ioloop = tornado.ioloop.IOLoop.instance()

--- a/nautilus/services/serviceManager.py
+++ b/nautilus/services/serviceManager.py
@@ -5,11 +5,14 @@
 
 # external imports
 import click
+# local imports
+from ..config import Config
 
 class ServiceManager:
 
-    def __init__(self, service):
+    def __init__(self, service, config=None):
         self.service = service
+        self.service_config = Config(config)
         self._running_service = False
 
         @click.group()
@@ -23,9 +26,18 @@ class ServiceManager:
         @group.command(help="Run the service.")
         @click.option('--port', default=8000, help="The port for the service http server.")
         @click.option('--host', default='127.0.0.1', help="The host for the http server.")
-        def runserver(port, host):
+        @click.option('--debug', default=False, is_flag=True, help="Run the service in debug mode.")
+        def runserver(port, host, debug):
             # make sure we clean up the service later on
             self._running_service = True
+            # the service configuration based on cli args
+            self.service_config.update(dict(
+                debug=debug
+            ))
+
+            # initialize the service with the config
+            service = self.service(config=self.service_config)
+
             # run the service
             service.run(
                 host = host,
@@ -47,7 +59,7 @@ class ServiceManager:
 
                 # notify the user
                 print("Successfully created necessary database tables.")
-                
+
             # otherwise there are no tables to create
             else:
                 print("There are no models to add.")


### PR DESCRIPTION
@janjaapbos: sorry it took so long to get this implemented (I've been busy writing tests)

This PR adds the debug flag to the ServiceManager. Since moving to the class-based approach for service definitions, providing the service's config as a class attribute is very natural. ie,

```python
class MyService(nautilus.Service):
    # can be Config, dict, or None
    config = Config(foo='bar')
```

Also, you can specify a config argument through the constructor that will get merged on-top of the internal configuration:

```
service = MyService(config={'bar': 'baz'})
```

Which will result in a service with a config equivalent to `{'foo': 'bar', 'bar': 'baz'}`. This allows a clean way for both the service and its manager to provide any kind of configuration when appropriate. One this way implemented (and tested), adding the `debug` flag was easy. The only down side to this that I can see is that the manager does not have the opportunity to clear the entire configuration of the service, but I'm not sure that's a problem. 