### PR TITLE
Added related model action handler to connection services

### DIFF
--- a/nautilus/auth/requestHandlers/register.py
+++ b/nautilus/auth/requestHandlers/register.py
@@ -55,9 +55,8 @@ class RegisterHandler(AuthRequestHandler):
             if UserPassword.select().where(match_query).count() > 0:
                 # yell loudly
                 raise ValueError("The user is already registered.")
-
             # create an entry in the user password table
-            password = UserPassword(**data, user=user_data['id'])
+            password = UserPassword(user=user_data['id'], **data)
             # save it to the database
             password.save()
 

--- a/nautilus/network/amqp/actionHandlers/__init__.py
+++ b/nautilus/network/amqp/actionHandlers/__init__.py
@@ -3,5 +3,5 @@ from .createHandler import create_handler
 from .updateHandler import update_handler
 from .deleteHandler import delete_handler
 
-def noop_handler(action_type, payload):
+def noop_handler(action_type, payload, dispatcher=None):
     return

--- a/nautilus/network/amqp/dispatch.py
+++ b/nautilus/network/amqp/dispatch.py
@@ -20,6 +20,7 @@ def dispatch(body, exchange, routing_key=''):
     # close the connection
     connection.close()
 
+
 def dispatch_action(action_type, payload):
     """
         This function dispatches an event over the action exchange with the designated

--- a/nautilus/network/amqp/util.py
+++ b/nautilus/network/amqp/util.py
@@ -1,6 +1,8 @@
 """
     This module defines various utilities for dealing with the network.
 """
+from collections.abc import Callable
+
 def combine_action_handlers(*args):
     """
         This function combines the given action handlers into a single function
@@ -10,6 +12,11 @@ def combine_action_handlers(*args):
     def combinedActionHandler(action_type, payload, dispatcher=None):
         # goes over every given handler
         for handler in args:
+            # if the handler is not a function
+            if not isinstance(handler, Callable):
+                # yell loudly
+                raise ValueError("Provided handler is not a function.")
+
             # call the handler
             handler(action_type, payload, dispatcher=dispatcher)
 

--- a/nautilus/network/amqp/util.py
+++ b/nautilus/network/amqp/util.py
@@ -8,17 +8,19 @@ def combine_action_handlers(*args):
         This function combines the given action handlers into a single function
         which will call all of them.
     """
+    # make sure each of the given handlers is callable
+    for handler in args:
+        # if the handler is not a function
+        if not isinstance(handler, Callable):
+            # yell loudly
+            raise ValueError("Provided handler is not a function: " + handler)
+
     # the combined action handler
-    def combinedActionHandler(action_type, payload, dispatcher=None):
+    def combined_handler(action_type, payload, dispatcher=None):
         # goes over every given handler
         for handler in args:
-            # if the handler is not a function
-            if not isinstance(handler, Callable):
-                # yell loudly
-                raise ValueError("Provided handler is not a function.")
-
             # call the handler
             handler(action_type, payload, dispatcher=dispatcher)
 
     # return the combined action handler
-    return combinedActionHandler
+    return combined_handler

--- a/nautilus/services/connectionService.py
+++ b/nautilus/services/connectionService.py
@@ -1,5 +1,6 @@
 # local imports
 from nautilus.api import create_model_schema
+from nautilus.network.amqp import combine_action_handlers
 from nautilus.network.amqp.actionHandlers import noop_handler
 from nautilus.conventions.services import connection_service_name
 from .modelService import ModelService
@@ -42,7 +43,6 @@ class ConnectionService(ModelService):
     """
 
     services = []
-    additional_action_handler = noop_handler
 
     def __init__(self, **kwargs):
 
@@ -58,11 +58,21 @@ class ConnectionService(ModelService):
                != len(self._service_models):
             raise ValueError("Can only connect models with different name")
 
+
         # create the service
         super().__init__(
             model=create_connection_model(self._service_models),
             name=connection_service_name(*self.services),
             **kwargs
+        )
+
+
+    @property
+    def action_handler(self):
+        return combine_action_handlers(
+            # combine the default model handlers
+            super().action_handler,
+
         )
 
 

--- a/nautilus/services/connectionService.py
+++ b/nautilus/services/connectionService.py
@@ -69,10 +69,19 @@ class ConnectionService(ModelService):
 
     @property
     def action_handler(self):
+        # a connection service should listen for deletes on linked services
+        connected_action_handlers = [self._create_linked_handler(model)
+                                     for model in self._service_models]
+        # print(connected_action_handlers)
+
         return combine_action_handlers(
             # combine the default model handlers
-            super().action_handler,
+            super().action_handler
         )
+
+
+    def _create_linked_handler(self, model): pass
+
 
 
     def get_base_models(self):

--- a/nautilus/services/connectionService.py
+++ b/nautilus/services/connectionService.py
@@ -72,7 +72,6 @@ class ConnectionService(ModelService):
         return combine_action_handlers(
             # combine the default model handlers
             super().action_handler,
-
         )
 
 

--- a/nautilus/services/modelService.py
+++ b/nautilus/services/modelService.py
@@ -52,15 +52,12 @@ class ModelService(Service):
             # yell loudly
             raise ValueError("Please provide a model for the model service.")
 
-        # the schema to add to the service
-        self.api_schema = create_model_schema(self.model)
-
         # pull the name of the service from kwargs if it was given
         name = kwargs.pop('name', None) or model_service_name(self.model)
 
         # create the service
         super().__init__(
-            schema=self.api_schema,
+            schema=create_model_schema(self.model),
             name=name,
             **kwargs
         )

--- a/nautilus/services/modelService.py
+++ b/nautilus/services/modelService.py
@@ -55,27 +55,31 @@ class ModelService(Service):
         # the schema to add to the service
         self.api_schema = create_model_schema(self.model)
 
-        # # the action handler is a combination
-        action_handler = combine_action_handlers(
-            # of the given one
-            self.additional_action_handler,
-            # and a crud handler
-            crud_handler(self.model)
-        )
-
         # pull the name of the service from kwargs if it was given
         name = kwargs.pop('name', None) or model_service_name(self.model)
 
         # create the service
         super().__init__(
             schema=self.api_schema,
-            action_handler=action_handler,
             name=name,
             **kwargs
         )
 
         # initialize the database
         self.init_db()
+
+
+    @property
+    def action_handler(self):
+        # combine the additional super handler with the crud one
+        return combine_action_handlers(
+            # combine the old action_handler
+            super().action_handler,
+            # allow for additional action handlers
+            self.additional_action_handler,
+            # and a crud handler
+            crud_handler(self.model)
+        )
 
 
     def init_db(self):

--- a/nautilus/services/service.py
+++ b/nautilus/services/service.py
@@ -4,6 +4,7 @@ import tornado.web
 # local imports
 from nautilus.network.amqp.consumers.actions import ActionHandler
 from nautilus.api.endpoints import static_dir as api_endpoint_static
+from nautilus.network.amqp.actionHandlers import noop_handler
 import nautilus.network.registry as registry
 from nautilus.config import Config
 from nautilus.api.endpoints import (
@@ -63,7 +64,6 @@ class Service(metaclass=ServiceMetaClass):
                     action_handler = crud_handler(Model)
     """
 
-    action_handler = None
     config = None
     name = None
     schema = None
@@ -82,7 +82,6 @@ class Service(metaclass=ServiceMetaClass):
         self.name = self.name or name or type(self).name
         self.app = None
         self.__name__ = name
-        self.action_handler = action_handler or self.action_handler
         self.keep_alive = None
         self._action_handler_loop = None
         self.schema = schema or self.schema
@@ -123,6 +122,12 @@ class Service(metaclass=ServiceMetaClass):
     def init_keep_alive(self):
         # create the period callback
         self.keep_alive = registry.keep_alive(self)
+
+
+    @property
+    def action_handler(self):
+        # by default, a service does not have a response to actions
+        return noop_handler
 
 
     def run(self, host="localhost", port=8000, **kwargs):

--- a/tests/services/test_connection_service.py
+++ b/tests/services/test_connection_service.py
@@ -79,7 +79,7 @@ class TestUtil(unittest.TestCase):
 
 
     def test_has_valid_schema(self):
-        assert hasattr(self.service, 'api_schema') and self.service.api_schema, (
+        assert hasattr(self.service, 'schema') and self.service.schema, (
             "Model Service did not have a schema."
         )
 
@@ -93,7 +93,7 @@ class TestUtil(unittest.TestCase):
         """ % self.service1.model.model_name
 
 
-        parsed_query = self.service.api_schema.execute(query)
+        parsed_query = self.service.schema.execute(query)
         # make sure there are no errors
         assert parsed_query.errors == [], (
             "Model service schema is invalid: " + str(parsed_query.errors)

--- a/tests/services/test_connection_service.py
+++ b/tests/services/test_connection_service.py
@@ -180,14 +180,18 @@ class TestUtil(unittest.TestCase):
         )
 
         # the action data for a related delete
-        action_type = conventions.get_crud_action('delete', self.service1.model)
-        payload = {self.service1.model.model_name: model1.id}
+        action_type = conventions.get_crud_action(
+            'delete', 
+            self.service1.model,
+            status='success'
+        )
+        payload = dict(id=model1.id)
 
         # fire the action
         self.service.action_handler(action_type, payload, dispatcher=MagicMock())
 
         # make sure the model can't be found
-        self.assertRaises(self.model.get, self.service1_value == model1.id)
+        self.assertRaises(Exception, self.model.get, self.service1_value == model1.id)
 
 
     ### Utilities / Test tasks
@@ -198,13 +202,12 @@ class TestUtil(unittest.TestCase):
             self.service1.model.model_name: 'foo',
             self.service2.model.model_name: 'bar'
         }
-        print(self.service.action_handler)
         # fire a create action
         self.service.action_handler(action_type, payload, dispatcher=MagicMock())
+        # the query to find a matching model
+        matching_model = self.service1_value == 'foo'
         # make sure the created record was found and save the id
-        self.model_id = self.model_id = self.model.get(
-            self.service1_value == 'foo'
-        ).id
+        self.model_id = self.model_id = self.model.get(matching_model).id
 
 
     def _verify_action_handler_update(self):

--- a/tests/services/test_model_service.py
+++ b/tests/services/test_model_service.py
@@ -48,7 +48,7 @@ class TestUtil(unittest.TestCase):
 
 
     def test_has_valid_schema(self):
-        assert hasattr(self.service, 'api_schema') and self.service.api_schema, (
+        assert hasattr(self.service, 'schema') and self.service.schema, (
             "Model Service did not have a schema."
         )
 
@@ -61,7 +61,7 @@ class TestUtil(unittest.TestCase):
             }
         """
 
-        parsed_query = self.service.api_schema.execute(query)
+        parsed_query = self.service.schema.execute(query)
 
         # make sure there are no errors
         assert parsed_query.errors == [], (

--- a/tests/services/test_service.py
+++ b/tests/services/test_service.py
@@ -29,15 +29,6 @@ class TestUtil(unittest.TestCase):
         )
 
 
-    def test_can_accept_action_handler(self):
-
-        def foo(): pass
-
-        assert self.service(action_handler=foo).action_handler == foo, (
-            "Service could not be initialized with a specific action_handler"
-        )
-
-
     def test_can_initialize_with_schema(self):
         # create a mock schema
         schema = MagicMock()


### PR DESCRIPTION
This PR resolves #17 and adds an action handler to connection services that removes entries from the database when a related model is successfully removed.

For example, all recipeIngredientConnections corresponding to the record with `recipe`=5 needs to be deleted when the `recipe` model with id 5 is successfully removed. 